### PR TITLE
Include "limited" label for "ask at"

### DIFF
--- a/app/helpers/library_items_helper.rb
+++ b/app/helpers/library_items_helper.rb
@@ -141,6 +141,8 @@ module LibraryItemsHelper
             status = '<div class="holdings-label label alert-error">Lost in lib<br/>' + hold + '</div>'
           elsif availability.downcase.include? "lib use"
             status = '<div class="holdings-label label alert-limited">Use in Library only</div>'
+	elsif availability.downcase.include? "ask at"
+            status = '<div class="holdings-label label alert-limited">Available on request</div>'
           else
             status = availability
           end


### PR DESCRIPTION
Feedback from Change Evaluation indicated that the yellow "limited availability" label should also be applied for items with a status of "Ask at . . ." Added this to the list of holdings-label cases.