### PR TITLE
Blac 178 additional

### DIFF
--- a/app/helpers/blah_helper.rb
+++ b/app/helpers/blah_helper.rb
@@ -477,7 +477,7 @@ ep_from_display" => "Item seperate from", "continued_by_display" => "Item contin
       content_tag(:i, '', :class => 'icon-globe')
     when 'CD Audio', 'Cassette', 'Sound record', 'Spoken record'
       content_tag(:i, '', :class => 'icon-volume-up')
-    when 'DVD'
+    when 'DVD', 'Blu-ray Disc'
       content_tag(:i, '', :class => 'icon-film')
     when 'Computer file'
         content_tag(:i, '', :class => 'icon-hdd')
@@ -485,7 +485,7 @@ ep_from_display" => "Item seperate from", "continued_by_display" => "Item contin
         content_tag(:i, '', :class => 'icon-briefcase')
     when 'Artefact'
         content_tag(:i, '', :class => 'icon-tag')
-    when 'Video'
+    when 'Video', 'Video cassette'
         content_tag(:i, '', :class => 'icon-facetime-video')
     else
       content_tag(:i, '', :class => 'icon-book')

--- a/app/views/catalog/_index_video.html.erb
+++ b/app/views/catalog/_index_video.html.erb
@@ -1,0 +1,6 @@
+<%= display_field_within_element(document, 'title_series_t' , element='h5') %>
+<%= display_field_within_element(document, 'author_t' , element='h5') %>
+<%= display_field_within_element(document, 'author_addl_t' , element='h5') %>
+<%= display_field_within_element(document, 'pub_date_display' , element='h5') %>
+
+<%= display_full_text_links(document) %>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -11,10 +11,6 @@
   <%= render :partial => 'shared/home_browse_tile' %>
   <%= render :partial => 'shared/home_quick_links_tile' %>             
 </div>
-
-<div class="row-fluid"> 
-  <%= render :partial => 'shared/home_announcement_tile' %>    
-</div>
     
 <div class="row-fluid">
   <%= render :partial => 'shared/home_twitter_tile' %>   

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -20,7 +20,6 @@
                  <li><a href="http://www2.hull.ac.uk/lli/library-services/opening-hours.aspx">Opening hours</a></li>
                  <li><a href="http://libguides.hull.ac.uk">LibGuides</a></li>
                  <li><a href="http://www2.hull.ac.uk/lli/library-services/books/interlibrary-loan.aspx" target="_blank">Inter-library loans</a></li>
-                 <li><a href="http://www2.hull.ac.uk/lli/library-services/books/intersite.aspx">Inter-site requests</a></li>
                 </ul>
               </div>
             </div>

--- a/app/views/shared/_home_help_search_text.html.erb
+++ b/app/views/shared/_home_help_search_text.html.erb
@@ -8,7 +8,7 @@
     <div id="collapseHelp" class="accordion-body collapse">
       <div class="accordion-inner">
 
-        <p>There are numerous ways to find what your looking for in the Library Catalogue, here's how:</p>
+        <p>There are numerous ways to find what you're looking for in the Library Catalogue:</p>
 
         <h3>Search</h3>
 

--- a/app/views/shared/_home_quick_links_tile.html.erb
+++ b/app/views/shared/_home_quick_links_tile.html.erb
@@ -38,10 +38,6 @@
             <%= link_to 'Inter-library loans →', 'http://www2.hull.ac.uk/lli/library-services/books/interlibrary-loan.aspx', :class => 'read-article', :title => 'Click for information about Inter-library loans'  %>
         </p>
         <p>
-            <i class="icon-retweet"></i>
-            <%= link_to 'Inter-site requests →', 'http://www2.hull.ac.uk/lli/library-services/books/intersite.aspx', :class => 'read-article', :title => 'Click for information about Inter-site requests'  %>
-        </p>
-        <p>
             <i class="icon-info-sign"></i>
             <%= link_to 'Suggest a purchase →', 'http://libguides.hull.ac.uk/c.php?g=91348&p=589126Suggest_Purchase.aspx', :class => 'read-article', :title => 'Click to go to the suggest a purchase form'  %>
         </p>

--- a/config/SolrMarc/blah_index.properties
+++ b/config/SolrMarc/blah_index.properties
@@ -214,11 +214,12 @@ map.format.r = Slide
 map.format.s = Playbill
 map.format.t = Thesis
 map.format.u = Video
-map.format.v = Video
+map.format.v = Video cassette
 #w - Book w/disk
 map.format.w = Book
 #x - Xerox
 map.format.x = Photocopy
+map.format.y = Blu-ray Disc
 map.format.@ = E-Book
 map.format = Unknown
 


### PR DESCRIPTION
Covers additional work on BLAC-178 (display of video formats) plus minor corrections

1. Main page: correct typo, remove outdated news items

2. Accommodate Blu-ray and video cassette formats, prevent display of holdings for online video

3.  Remove Inter-site links (menu, footer) in preparation for closure of Scarborough library