### PR TITLE
Blac 185

### DIFF
--- a/app/helpers/blah_helper.rb
+++ b/app/helpers/blah_helper.rb
@@ -282,13 +282,13 @@ module BlahHelper
         unless author.nil? || author.empty?
           author = author.split(",")[0]
         else
-          if author_addl.nil? || author_addl.empty?
+          unless author_addl.nil? || author_addl.empty?
             author = author_addl.split(",")[0]
           else
             author = ""
           end
         end
-        params = (CGI.escape(title) + "&" + author).html_safe
+        params = (CGI.escape(title) + "+" + author).html_safe
         target_url = (york_link_url + params).html_safe
       when 'Journal', 'E-Journal'
         # get ISSN :  022 |a field

--- a/app/models/library_item.rb
+++ b/app/models/library_item.rb
@@ -13,12 +13,13 @@ class LibraryItem
 
   # Can the item be request/put on hold.. The item availaility needs to be false and there needs to be holding information stored for the item
   # Item is requestable if any of the requestable_locations (See blah config file) copies are unavailable
+  # Modified requestable rules for new reservation service: all items with holdings in a requestable location are requestable regardless of availability
   def requestable?
     requestable = false
 
     LibraryItem.requestable_locations.each do |location_prefix|
       available = self.send("available_at_#{location_prefix}?")
-      requestable = !available.nil? && !available ? true : false
+      requestable = !available.nil?  ? true : false
       break if requestable
     end
     requestable

--- a/app/views/catalog/_show_availability.html.erb
+++ b/app/views/catalog/_show_availability.html.erb
@@ -18,9 +18,6 @@
   <% unless @document["format"] == "E-Journal" || 
     @document["format"] == "E-Book" ||
     @document["format"] == "Electronic resource" %>
-    <p>
-      <%= link_to "Intersite transfer", APP_CONFIG['intersite_transfer_url'], :target => "_blank" %>
-    </p>
   <% end %>
 
 </div>

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -46,11 +46,7 @@
         </li>
       <% end %>
 
-      <% if item_bookable?(@document) %>
-        <li class="book_item">
-          <%= render_bookable_library_item_link(@library_item, "btn btn-small square-corners") %>
-        </li>
-      <% end %>
+      
     <% end %>
     <%= render :partial => 'qr_code' %>
     <%= render :partial => 'addthis_tool' %>
@@ -95,11 +91,7 @@
               </li>
             <% end %>
 
-            <% if item_bookable?(@document) %>
-              <li class="book_item">
-                <%= render_request_library_item_link(@library_item, "") %>
-              </li>
-            <% end %>
+            
           <% end %>
 
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -17,9 +17,9 @@
                     <h4>Library</h4>
                   </li>
                  <li><a href="http://www.hull.ac.uk/lib">Library Website</a></li>
-                 <li><a href="http://www2.hull.ac.uk/lli/library-services/opening-hours.aspx">Opening hours</a></li>
-                 <li><a href="http://libguides.hull.ac.uk">LibGuides</a></li>
-                 <li><a href="http://www2.hull.ac.uk/lli/library-services/books/interlibrary-loan.aspx" target="_blank">Inter-library loans</a></li>
+                 <li><a href="http://www.hull.ac.uk/Choose-Hull/Study-at-Hull/Library/index.aspx#OpeningTimes">Opening hours</a></li>
+                 <li><a href="http://www.hull.ac.uk/Choose-Hull/Study-at-Hull/Library/resources/libguides/Subject-LibGuides.aspx">Subject LibGuides</a></li>
+                 <li><a href="http://www.hull.ac.uk/Choose-Hull/Study-at-Hull/Library/services/Borrowing/Inter-Library-Loans.aspx">Inter-library loans</a></li>
                 </ul>
               </div>
             </div>
@@ -32,8 +32,8 @@
                    <li><a href="http://canvas.hull.ac.uk">Canvas</a></li>
                    <li><a href="http://readinglists.hull.ac.uk">Readinglists@Hull</a></li>
                    <li><a href="http://digitaltexts.hull.ac.uk">Digital Texts</a></li>
-                   <li><a href="http://libcal.hull.ac.uk">Room & course bookings</a></li>
-                   <li><a href="http://www2.hull.ac.uk/lli/library-services/help_and_support.aspx">Ask us a question</a></li>
+                   <li><a href="http://libcal.hull.ac.uk/booking/studyspace">Group Learning Room bookings</a></li>
+                   <li><a href="http://libanswers.hull.ac.uk/">Ask us a question</a></li>
                 </ul>
             </div>
               </div>
@@ -43,11 +43,11 @@
                      <li>                  
                        <h4>Skills</h4>
                      </li>
-                     <li><a href="http://www2.hull.ac.uk/lli/skills-development.aspx">Skills website</a></li>
+                     <li><a href="http://www.hull.ac.uk/skills">Skills website</a></li>
                      <ul class="footer-sub-list">
                        <li><a href="http://www.skills4studycampus.com/orglogin.aspx">skills4studycampus</a></li>
-                       <li><a href="http://libguides.hull.ac.uk/studentworkshops">Study Skills Workshop</a></li>
-                       <li><a href="https://myadmin.hull.ac.uk/Students/DiaryBookings/AppointmentCriteria.aspx">Book an Appointment</a></li>
+                       <li><a href="http://libguides.hull.ac.uk/skillsworkshops>Study Skills Workshop"</a></li>
+                       <li><a href="http://www.hull.ac.uk/Choose-Hull/Study-at-Hull/Library/skills/Book-an-Appointment.aspx">Book an Appointment</a></li>
                      </ul>                    
                   </ul>
                 </div>
@@ -59,11 +59,12 @@
                        <li>
                          <h4>University</h4>
                        </li>
-                       <li><a href="http://www.hull.ac.uk">University website</a></li>
-                       <li><a href="http://portal.hull.ac.uk">University portal</a></li>
-                       <li><a href="https://hull.avedas.com/converis/area/3734">Research portal</a></li>
-                       <li><a href="http://www2.hull.ac.uk/departments.aspx">Departments and faculties</a></li>
+                       <li><a href="http://www.hull.ac.uk">University Website</a></li>
+                       <li><a href="http://share.hull.ac.uk">SharePoint</a></li>
+                      <li><a href="http://www.hull.ac.uk/Choose-Hull/Study-at-Hull/Library/research/index.aspx">Research Services</a></li>
+                      <li><a href="https://hull-research.worktribe.com">Research portal</a></li>
                        <li><a href="http://hydra.hull.ac.uk">Hydra digital repository</a></li>
+                      <li><a href="http://www.hullhsitorycentre.org.uk">Hull History Centre</a></li>
                     </ul>
                   </div>
              </div>

--- a/app/views/shared/_home_quick_links_tile.html.erb
+++ b/app/views/shared/_home_quick_links_tile.html.erb
@@ -11,15 +11,15 @@
         </p>
         <p>
             <i class="icon-question-sign"></i>
-            <%= link_to 'Help →', 'http://www2.hull.ac.uk/lli/library-services/help_and_support.aspx', :class => 'read-article', :title => 'Click to go to Help'  %>
+            <%= link_to 'Help →', 'http://libanswers.hull.ac.uk/', :class => 'read-article', :title => 'Click to go to Help'  %>
         </p>
         <p>
             <i class="icon-pencil"></i>
-            <%= link_to 'Libguides →', 'http://libguides.hull.ac.uk', :class => 'read-article', :title => 'Click to go to Libguides'  %>
+            <%= link_to 'Subject LibGuides →', 'http://www.hull.ac.uk/Choose-Hull/Study-at-Hull/Library/resources/libguides/Subject-LibGuides.aspx', :class => 'read-article', :title => 'Click to go to Subject LibGuides'  %>
         </p>
         <p>
             <i class="icon-time"></i>
-            <%= link_to 'Opening hours →', 'http://www2.hull.ac.uk/lli/library-services/opening-hours.aspx', :class => 'read-article', :title => 'Click to go to Opening hours'  %>
+            <%= link_to 'Opening hours →', 'http://www.hull.ac.uk/Choose-Hull/Study-at-Hull/Library/index.aspx#OpeningTimes', :class => 'read-article', :title => 'Click to go to Opening hours'  %>
         </p>
         <p>
             <i class="icon-search"></i>
@@ -31,16 +31,15 @@
         </p>
         <p>
             <i class="icon-file"></i>
-            <%= link_to 'Exam papers →', 'http://www2.hull.ac.uk/lli/library-services/books/exam-papers.aspx', :class => 'read-article', :title => 'Click to go to the Exam papers information page'  %>
+            <%= link_to 'Exam papers →', 'http://www.hull.ac.uk/Choose-Hull/Study-at-Hull/Library/resources/electronic-resources/exampapers.aspx', :class => 'read-article', :title => 'Click to go to the Exam papers information page'  %>
         </p>        
         <p>
             <i class="icon-retweet"></i>
-            <%= link_to 'Inter-library loans →', 'http://www2.hull.ac.uk/lli/library-services/books/interlibrary-loan.aspx', :class => 'read-article', :title => 'Click for information about Inter-library loans'  %>
+            <%= link_to 'Inter-library loans →', 'http://www.hull.ac.uk/Choose-Hull/Study-at-Hull/Library/services/Borrowing/Inter-Library-Loans.aspx', :class => 'read-article', :title => 'Click for information about Inter-library loans'  %>
         </p>
         <p>
             <i class="icon-info-sign"></i>
-            <%= link_to 'Suggest a purchase →', 'http://libguides.hull.ac.uk/c.php?g=91348&p=589126Suggest_Purchase.aspx', :class => 'read-article', :title => 'Click to go to the suggest a purchase form'  %>
-        </p>
+            <%= link_to 'Suggest a purchase →', 'http://www.hull.ac.uk/Choose-Hull/Study-at-Hull/Library/services/Borrowing/suggest-a-purchase.aspx', :class => 'read-article', :title => 'Click to go to the suggest a purchase form'  %>
         <p>
             <i class="icon-info-sign"></i>
             <%= link_to 'Cookies →', '/cookies', :class => 'read-article', :title => 'Click to go to Cookies'  %>


### PR DESCRIPTION
This release features the following fixes and enhancements:

1. Record page errors on click through if neither an author nor additional author is present in the data. Corrected logic that assembles link to York Library catalog to prevent this. Additionally, the construction of the search parameters for York fail to include author data--now corrected. (JIRA BLAC-185)

2. Reservation service to be implemented requires that all physical items can be requested regardless of availability (currently only if all on loan). Changed definition of "requestable" variable, and removed "Book" button (now superfluous for short loan items)

3. Updates to links on main page and footer, changed as a result of new University Library Website, new University systems etc. Removed link on record pages to Inter-site requests service following closure of branch