### PR TITLE
UAT feedback on CER‌-0009: subject presentation

### DIFF
--- a/app/helpers/blah_helper.rb
+++ b/app/helpers/blah_helper.rb
@@ -239,7 +239,7 @@ module BlahHelper
 
       display_field = <<-EOS
         <dt class=#{dd_class}>#{label}</dt>
-        <dd class=#{dd_class}>#{values.collect{ |value| search_catalog_link(value, value, search_field, link_class, true)}.join('; ') }</dd>
+        <dd class=#{dd_class}>#{values.collect{ |value| search_catalog_link(value, value, search_field, link_class, true) + '.'}.join('<br/>') }</dd>
       EOS
     end
 

--- a/config/SolrMarc/blah_index.properties
+++ b/config/SolrMarc/blah_index.properties
@@ -74,7 +74,7 @@ author_facet = custom, getLinkedFieldCombined(100abcdegqu:110abcdegnu:111[a-z]:7
 #############################################
 # Subject fields
 #############################################
-subject_t = custom, getLinkedFieldCombined(600[a-z]:610[a-z]:611[a-z]:630[a-z]:650[a-z]:651[a-z]:653aa:654[a-z]:655[a-z])
+subject_t = custom, getAllSubfields(600[a-z]:610[a-z]:611[a-z]:630[a-z]:650[a-z]:651[a-z]:653aa:654[a-z]:655[a-z]," -- ")
 subject_addl_t = ""
 subject_topic_facet = custom, removeTrailingPunct(600abcdq:610ab:611ab:630aa:650aa:653aa:654ab:655ab)
 subject_era_facet = custom, removeTrailingPunct(650y:651y:654y:655y)


### PR DESCRIPTION
UAT feedback on CER‌-0009 highlighted the value of hyphenating subject terms and presenting each on a separate line.

The latter can be achieved fairly easily by modifying the “join” value of display_field_search_link helper in blah_helper.rb. A further request to terminate each subject field with a full stop can be accommodated in the same method.

Hyphenating at the subfield is more complex, since the variable “subject_t” is defined in the blah_index.properties file as a composite of each 600 subject field and its subfields.  An alternate custom indexing method used in blah does have the option of specifying a seperator other than the default space. If this method is used when indexing subject_t, with the hyphenation string set as a parameter, the desired result is achieved.