### PR TITLE
LBC-27

### DIFF
--- a/app/helpers/blah_helper.rb
+++ b/app/helpers/blah_helper.rb
@@ -149,6 +149,16 @@ module BlahHelper
       render :partial => 'catalog/online_resources'
     end
   end
+  
+  def render_archival_material_partial(document)
+    #Get the url fields...        
+    full_text_url_display = document.get('url_fulltext_display', :sep => nil)
+
+    #Check online resources exist...
+    unless full_text_url_display.nil?
+      render :partial => 'catalog/archival_material'
+    end
+  end
 
   def display_field(document, solr_fname, label_text='', dd_class=nil, opts={} )
 
@@ -477,6 +487,8 @@ ep_from_display" => "Item seperate from", "continued_by_display" => "Item contin
         content_tag(:i, '', :class => 'icon-briefcase')
     when 'Microform'
         content_tag(:i, '', :class => 'icon-th')
+    when 'Archival material'
+        content_tag(:i, '', :class => 'icon-folder-close')
     else
       content_tag(:i, '', :class => 'icon-book')
     end

--- a/app/views/catalog/_archival_material.html.erb
+++ b/app/views/catalog/_archival_material.html.erb
@@ -1,0 +1,14 @@
+<div class="holdings">
+  <div class="table-container">
+    <table class="table availability-table">
+      <thead>
+        <tr>   
+          <td colspan="3"><h5>Hull History Centre</h5><h5></h5></td>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render_online_resources (@document) %>        
+      </tbody>
+		</table>
+  </div>
+</div>

--- a/app/views/catalog/_index_archival_material.html.erb
+++ b/app/views/catalog/_index_archival_material.html.erb
@@ -1,0 +1,3 @@
+<%# default partial to display solr document fields in catalog index view -%>
+<%= display_field_within_element(document, 'id' , element='small') %>
+<%= display_field(document, 'url_fulltext_display', 'Hull History Centre', 'hull history centre', {:display_as_link => true, :link_text => 'View details in the History Centre catalogue'}) %>

--- a/app/views/catalog/_show_archival_material.html.erb
+++ b/app/views/catalog/_show_archival_material.html.erb
@@ -1,0 +1,22 @@
+<div class="row-fluid">
+  <div id="document-header" class="span16">
+    <%= render_document_heading(:h2).html_safe %> 
+  </div>
+</div>
+<div class="row-fluid">
+     <div class="span12">
+        <h3>Record</h3>
+        <dl class="dl-vertical-left  dl-invert">
+          <%= display_field(document, 'description_display', 'Description', 'description', {:contains_encoded_html => true}) %>
+          <%#= display_field(document, 'subject_t', 'Subject', 'subject') %>
+          <%= display_field_search_link(document, 'subject_t', 'Subject', 'subject', 'subject-link', 'subject') %>
+          <%= display_field(document, 'format', 'Format', 'format') %>
+          <%= display_field(document, 'id', 'Reference no', 'ref') %>
+          <%= display_field(document, 'coverage_display', 'Date', 'date') %>
+        </dl>
+        <h3>Access information</h3>
+        <dl class="dl-vertical-left  dl-invert">
+          <%= display_field(document, 'access_info_display', 'Access', 'access-info', {:contains_encoded_html => true}) %>
+        </dl>
+     </div>
+</div>

--- a/app/views/catalog/_show_availability.html.erb
+++ b/app/views/catalog/_show_availability.html.erb
@@ -5,19 +5,19 @@
   <% if !@library_item.nil? && @library_item.inter_library_loan? %>
       <p>Available through <%= link_to "Inter-Library Loan", inter_library_loan_url %></p>
   <% else %>
-    <% unless @document["format"] == "Electronic resource" %>
+    <% unless @document["format"] == "Electronic resource" || @document["format"]  == "Archival material" %>
       <p><%= render_millennium_record_link "Find loan period information here" %></p>
     <% end %>
   <% end %>
 
+
   <% #This will be set to display:block using javascript if no holdings/online resources are present -See holdings_record.js -%>
   <p id="no-holdings" class="hide"><%= t('blah.item.holdings.no_holdings_information') %></p>
   <%= render_holdings_html_partial(@library_item) unless @library_item.nil? %>
-  <%= render_online_resources_partial(@document) %>
-
-  <% unless @document["format"] == "E-Journal" || 
-    @document["format"] == "E-Book" ||
-    @document["format"] == "Electronic resource" %>
-  <% end %>
-
+<% if @document["format"] == "E-Journal" || @document["format"] == "E-Book" || @document["format"] == "E-Thesis" || @document["format"] == "Electronic resource" %>
+<%= render_online_resources_partial(@document) %>
+<% end %>  
+<% if @document["format"] == "Archival material" %>
+<%= render_archival_material_partial(@document) %>
+<% end %>
 </div>

--- a/config/blah_config.yml
+++ b/config/blah_config.yml
@@ -44,6 +44,7 @@ development:
       - 'E-Thesis'
       - 'Video'
       - 'Electronic resource'
+      - 'Archival material'
       - 'Unknown'
 
   #status from holding records
@@ -136,6 +137,7 @@ test:
       - 'E-Thesis'
       - 'Video'
       - 'Electronic resource'
+      - 'Archival material'
       - 'Unknown'
 
    #status from holding records
@@ -227,6 +229,7 @@ production:
       - 'E-Thesis'
       - 'Video'
       - 'Electronic resource'
+      - 'Archival material'
       - 'Unknown'
 
    #status from holding records


### PR DESCRIPTION
Simple method for the inclusion of History Center archival material records in the Library catalogue. Uses existing CSV indexing rake task for electronic resource records.

Development provides handling for the "Archival material" format, presenting a link to the full record in the HHC catalogue, with an appropriately titled holdings table and fields repurposed from the ERM model.

The index_data task should be used rather than the delete and index method used in the ERM workflow.